### PR TITLE
Bumping scanr-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "image to text api",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
@sagivo,
we need to bump the version number and also publish the npm package again for scanr-node (https://www.npmjs.com/package/scanr) so that users can get the version with the fixes when they do an `npm install`
